### PR TITLE
[frontend] ルーティングを設定して各ページを表示できるようにする

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>GitHub Stats Metrics</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,13 +1,23 @@
+import { NavLink } from 'react-router-dom';
 import './App.css'
-import { BrowserRouter } from 'react-router-dom';
-import { SprintList } from './features/sprintlist/SprintList';
+import { AppRouter } from './Router';
 
 export const App = () => {
   return (
     <>
-      <BrowserRouter>
-        <SprintList/>
-      </BrowserRouter>
+      <h1 className='pl-24 font-bold'>GitHub Metrics Tracker</h1>
+      <aside className='fixed top-0 left-0 h-screen'>
+        <div className='h-full px-8 py-4 bg-gray-100'>
+          <h2 className='py-1 font-bold'>Menu</h2>
+          <ul>
+            <li><NavLink to='/'>Chart</NavLink></li>
+            <li><NavLink to='/sprints'>Sprints</NavLink></li>
+          </ul>
+        </div>
+      </aside>
+      <div className='pl-24'>
+        <AppRouter />
+      </div>
     </>
   )
 }

--- a/frontend/src/Router.tsx
+++ b/frontend/src/Router.tsx
@@ -1,0 +1,14 @@
+import { Route, Routes } from 'react-router-dom';
+import { SprintList } from './features/sprintlist/SprintList';
+import { Chart } from './features/pullrequestlist/Chart';
+
+export const AppRouter = () => {
+    return (
+        <Routes>
+            <Route path='/' element={<Chart />} />
+            <Route path='sprints' >
+                <Route index element={<SprintList />} />
+            </Route>
+        </Routes>
+    )
+}

--- a/frontend/src/Router.tsx
+++ b/frontend/src/Router.tsx
@@ -1,6 +1,7 @@
 import { Route, Routes } from 'react-router-dom';
 import { SprintList } from './features/sprintlist/SprintList';
 import { Chart } from './features/pullrequestlist/Chart';
+import { SprintDetail } from './features/sprint/SprintDetail';
 
 export const AppRouter = () => {
     return (
@@ -8,6 +9,7 @@ export const AppRouter = () => {
             <Route path='/' element={<Chart />} />
             <Route path='sprints' >
                 <Route index element={<SprintList />} />
+                <Route path=':sprintId' element={<SprintDetail />} />
             </Route>
         </Routes>
     )

--- a/frontend/src/features/pullrequestlist/Chart.tsx
+++ b/frontend/src/features/pullrequestlist/Chart.tsx
@@ -1,75 +1,71 @@
 import { ApexOptions } from "apexcharts";
-import ReactApexChart from "react-apexcharts";
 import { PR } from "./PullRequest";
 
-type ChartProps = {
-  prs: PR[]|undefined
-}
+export const Chart = () => {
+  // const prIds = prs?.map((pr: PR) => {return pr.id})
+  //  const betweenFirstReviewAndCreated = prs?.map((pr: PR) => {
+  //   return pr.firstReviewed.getTime() - pr.created.getTime()
+  // }) ?? []
+  // const betweenLastApprovedAndFirstReviewed = prs?.map((pr: PR) => {
+  //   return pr.lastApproved.getTime() - pr.firstReviewed.getTime()
+  // }) ?? []
+  // const betweenMergedAndLastApproved = prs?.map((pr: PR) => {
+  //   return pr.merged.getTime() - pr.lastApproved.getTime()
+  // }) ?? []
 
-export const Chart: React.FC<ChartProps> = ({prs}) => {
-  const prIds = prs?.map((pr: PR) => {return pr.id})
-   const betweenFirstReviewAndCreated = prs?.map((pr: PR) => {
-    return pr.firstReviewed.getTime() - pr.created.getTime()
-  }) ?? []
-  const betweenLastApprovedAndFirstReviewed = prs?.map((pr: PR) => {
-    return pr.lastApproved.getTime() - pr.firstReviewed.getTime()
-  }) ?? []
-  const betweenMergedAndLastApproved = prs?.map((pr: PR) => {
-    return pr.merged.getTime() - pr.lastApproved.getTime()
-  }) ?? []
-
-  const chartData: ApexOptions = {
-      chart: {
-        type: "line",
-        id: "apexchart-example",
-        stacked: true,
-      },
-      xaxis: {
-        categories: prIds
-      },
-      fill: {
-        type: "gradient",
-        gradient: {
-          shade: "light",
-          type: "horizontal",
-          shadeIntensity: 0.5,
-          gradientToColors: undefined, // optional, if not defined - uses the shades of same color in series
-          inverseColors: true,
-          opacityFrom: 1,
-          opacityTo: 1,
-          stops: [0, 50, 100]
-        }
-      },
-      legend: {
-        // position: '',
-        width: 300
-        // position: 'top',
-      },
-      series: [
-        {
-          name: "betweenFirstReviewAndCreated",
-          type: "column",
-          data: betweenFirstReviewAndCreated,
-        },
-        {
-            name: "betweenLastApprovedAndFirstReviewed",
-            type: "column",
-            data: betweenLastApprovedAndFirstReviewed,
-        },
-        {
-          name: "betweenMergedAndLastApproved",
-          type: "column",
-          data: betweenMergedAndLastApproved,
-        }, 
-        {
-          name: "Time Traveled",
-          type: "line",
-          data: [23, 42, 35, 27, 43, 22, 17, 31, 42, 22, 12, 16],
-        }
-      ]
-    };
+  // const chartData: ApexOptions = {
+  //     chart: {
+  //       type: "line",
+  //       id: "apexchart-example",
+  //       stacked: true,
+  //     },
+  //     xaxis: {
+  //       categories: prIds
+  //     },
+  //     fill: {
+  //       type: "gradient",
+  //       gradient: {
+  //         shade: "light",
+  //         type: "horizontal",
+  //         shadeIntensity: 0.5,
+  //         gradientToColors: undefined, // optional, if not defined - uses the shades of same color in series
+  //         inverseColors: true,
+  //         opacityFrom: 1,
+  //         opacityTo: 1,
+  //         stops: [0, 50, 100]
+  //       }
+  //     },
+  //     legend: {
+  //       // position: '',
+  //       width: 300
+  //       // position: 'top',
+  //     },
+  //     series: [
+  //       {
+  //         name: "betweenFirstReviewAndCreated",
+  //         type: "column",
+  //         data: betweenFirstReviewAndCreated,
+  //       },
+  //       {
+  //           name: "betweenLastApprovedAndFirstReviewed",
+  //           type: "column",
+  //           data: betweenLastApprovedAndFirstReviewed,
+  //       },
+  //       {
+  //         name: "betweenMergedAndLastApproved",
+  //         type: "column",
+  //         data: betweenMergedAndLastApproved,
+  //       }, 
+  //       {
+  //         name: "Time Traveled",
+  //         type: "line",
+  //         data: [23, 42, 35, 27, 43, 22, 17, 31, 42, 22, 12, 16],
+  //       }
+  //     ]
+  //   };
   
     return (
-        <ReactApexChart options={chartData} series={chartData.series} />
+        // <ReactApexChart options={chartData} series={chartData.series} />
+        <h1>Chart Page</h1>
     );
 };

--- a/frontend/src/features/pullrequestlist/Chart.tsx
+++ b/frontend/src/features/pullrequestlist/Chart.tsx
@@ -1,6 +1,3 @@
-import { ApexOptions } from "apexcharts";
-import { PR } from "./PullRequest";
-
 export const Chart = () => {
   // const prIds = prs?.map((pr: PR) => {return pr.id})
   //  const betweenFirstReviewAndCreated = prs?.map((pr: PR) => {

--- a/frontend/src/features/pullrequestlist/PullRequestList.tsx
+++ b/frontend/src/features/pullrequestlist/PullRequestList.tsx
@@ -37,7 +37,7 @@ export const PullRequestList = () => {
 
     return (
         <>
-            <h1>プルリクエスト一覧</h1>
+            <h1 className="text-left">プルリクエスト一覧</h1>
 
             <div className="flex overflow-x-auto">
                 <table className="flex-none divide-y divide-gray-200 dark:divide-gray-700">

--- a/frontend/src/features/sprint/SprintDetail.tsx
+++ b/frontend/src/features/sprint/SprintDetail.tsx
@@ -1,0 +1,15 @@
+import { useParams } from "react-router-dom"
+import { PullRequestList } from "../pullrequestlist/PullRequestList"
+type Params = {
+    sprintId?: string
+}
+
+export const SprintDetail = () => {
+    const params: Params = useParams<Params>()
+    return (
+        <>
+            <h2>{'Sprint ' + params?.sprintId}</h2>
+            <PullRequestList/>
+        </>
+    )
+}

--- a/frontend/src/features/sprintlist/SprintList.tsx
+++ b/frontend/src/features/sprintlist/SprintList.tsx
@@ -6,10 +6,11 @@ export const SprintList = () => {
     const [sprintList, setSprintList] = useState<Sprint[]>([])
 
     useEffect(() => {
-        const result = GetSprintList();
-    
-        setSprintList(result)    
-    })
+        const fetchSprintList = async () => {
+            setSprintList(GetSprintList())
+        }
+        fetchSprintList()
+    }, [])
 
     return (
         <table className='divide-y divide-gray-200 dark:divide-gray-700'>

--- a/frontend/src/features/sprintlist/SprintRow.tsx
+++ b/frontend/src/features/sprintlist/SprintRow.tsx
@@ -24,10 +24,10 @@ export const SprintRow: React.FC<SprintProp> = ({sprint}) => {
             <td>{sprint.endDate.toISOString().split('T')[0]}</td>
             <td className="text-left">
                 {sprint.members.map(
-                    (member: Member) => <img className="inline-block pr-1" src={member.iconURL} width={20} />
+                    (member: Member) => <img key={member.name} className="inline-block pr-1" src={member.iconURL} width={20} />
                 )}
             </td>
-            <td><Link to={'/sprints/' + sprint.id}>詳細</Link></td>
+            <td><Link to={sprint.id.toString()}>詳細</Link></td>
         </tr>
     )
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import './index.css'
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
-import { BrowserRouter, RouterProvider } from 'react-router-dom'
+import { BrowserRouter } from 'react-router-dom'
 import { App } from './App.tsx'
 
 const queryClient: QueryClient = new QueryClient({

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import { App } from './App.tsx'
 import './index.css'
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
+import { BrowserRouter, RouterProvider } from 'react-router-dom'
+import { App } from './App.tsx'
 
 const queryClient: QueryClient = new QueryClient({
   defaultOptions: {
@@ -14,8 +15,10 @@ const queryClient: QueryClient = new QueryClient({
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <App />
-    </QueryClientProvider>
+    <BrowserRouter>
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
+    </BrowserRouter>
   </React.StrictMode>,
 )


### PR DESCRIPTION
# 概要

ルーティングを設定して、以下のページをそれぞれ表示できるようにした

- グラフページ
- スプリント一覧ページ
- スプリント詳細ページ

また、サイドバーを表示して上記のページ群を右側に表示できるようにレイアウトを調整した。