### PR TITLE
hotfix: リポジトリ名の文字列連結をしてクエリを作成する際、リポジトリ名間にスペースを含めていなかった不具合を修正

### DIFF
--- a/backend/app/infrastructure/github_api/github_api.go
+++ b/backend/app/infrastructure/github_api/github_api.go
@@ -98,7 +98,7 @@ func createQuery(startDate string, endDate string, developers []string) string {
 
 	// リポジトリ
 	repositories := strings.Split(os.Getenv("GITHUB_GRAPHQL_SEARCH_QUERY_TARGET_REPOSITORIES"), ",")
-	query += "repo:" + strings.Join(repositories, "repo:") + " "
+	query += "repo:" + strings.Join(repositories, " repo:") + " "
 
 	// 開発者
 	query += "author:" + strings.Join(developers, " author:")


### PR DESCRIPTION
# 概要

表題の通り。

コミット漏れによりバグが発生した。

