### PR TITLE
[frontend] スプリント毎にそのスプリントでmergeしたPR一覧を取得するようにした

### DIFF
--- a/frontend/src/features/pullrequestlist/PullRequestList.tsx
+++ b/frontend/src/features/pullrequestlist/PullRequestList.tsx
@@ -57,25 +57,29 @@ export const PullRequestList: React.FC<PullRequestListProp> = ({sprint}) => {
         <>
             <h1 className="text-left">プルリクエスト一覧</h1>
 
-            <div className="flex overflow-x-auto">
-                <table className="flex-none divide-y divide-gray-200 dark:divide-gray-700">
-                    <thead>
-                        <tr>
-                            <th scope="col" className="pl-4 py-2 text-start text-xs font-medium text-gray-500 ">ID</th>
-                            <th scope="col" className="pl-4 py-2 text-start text-xs font-medium text-gray-500 ">Author</th>
-                            <th scope="col" className="pl-4 py-2 text-start text-xs font-medium text-gray-500 ">初回レビューまで</th>
-                            <th scope="col" className="pl-4 py-2 text-start text-xs font-medium text-gray-500 ">初回〜最終Aprvまで</th>
-                            <th scope="col" className="pl-4 py-2 text-start text-xs font-medium text-gray-500 ">最終Aprv〜Mergeまで</th>
-                            <th scope="col" className="pl-4 py-2 text-start text-xs font-medium text-gray-500 ">Title</th>
-                        </tr>
-                    </thead>
-                    <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
-                        {pullRequests?.map((pr: PR) => {
-                            return <PullRequest key={pr.id} pr={pr} />;
-                        })}
-                    </tbody>
-                </table>
-            </div>
+            {pullRequests ? (
+                <div className="flex overflow-x-auto">
+                    <table className="flex-none divide-y divide-gray-200 dark:divide-gray-700">
+                        <thead>
+                            <tr>
+                                <th scope="col" className="pl-4 py-2 text-start text-xs font-medium text-gray-500 ">ID</th>
+                                <th scope="col" className="pl-4 py-2 text-start text-xs font-medium text-gray-500 ">Author</th>
+                                <th scope="col" className="pl-4 py-2 text-start text-xs font-medium text-gray-500 ">初回レビューまで</th>
+                                <th scope="col" className="pl-4 py-2 text-start text-xs font-medium text-gray-500 ">初回〜最終Aprvまで</th>
+                                <th scope="col" className="pl-4 py-2 text-start text-xs font-medium text-gray-500 ">最終Aprv〜Mergeまで</th>
+                                <th scope="col" className="pl-4 py-2 text-start text-xs font-medium text-gray-500 ">Title</th>
+                            </tr>
+                        </thead>
+                        <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+                            {pullRequests.map((pr: PR) => {
+                                return <PullRequest key={pr.id} pr={pr} />;
+                            })}
+                        </tbody>
+                    </table>
+                </div>
+            ) : 
+                <div>Loading...</div>
+            }
         </>
     )
 }

--- a/frontend/src/features/pullrequestlist/PullRequestList.tsx
+++ b/frontend/src/features/pullrequestlist/PullRequestList.tsx
@@ -8,9 +8,18 @@ type PullRequestListProp = {
 
 export const PullRequestList: React.FC<PullRequestListProp> = ({sprint}) => {
     const [pullRequests, setPullRequests] = useState<PR[]>([]);
-  
+
+    const params = {
+        startdate : sprint.startDate.toISOString().split('T')[0],
+        enddate: sprint.endDate.toISOString().split('T')[0],
+    };
+    const queryParameters = new URLSearchParams(params);
+    sprint.members.map(
+        (member: Member) => queryParameters.append('developers', member.name)
+    )
+
     useEffect(() => {
-        fetch('http://localhost:8080/api/pull_requests')
+        fetch(`http://localhost:8080/api/pull_requests?${queryParameters}`)
         .then((res) => res.json())
         .then((data) => {
             const result: PR[] = [];

--- a/frontend/src/features/pullrequestlist/PullRequestList.tsx
+++ b/frontend/src/features/pullrequestlist/PullRequestList.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useState } from "react";
 import { PullRequest, PR } from "./PullRequest";
+import { Member, Sprint } from "../sprintlist/SprintRow";
 
-export const PullRequestList = () => {
+type PullRequestListProp = {
+    sprint: Sprint
+}
+
+export const PullRequestList: React.FC<PullRequestListProp> = ({sprint}) => {
     const [pullRequests, setPullRequests] = useState<PR[]>([]);
   
     useEffect(() => {

--- a/frontend/src/features/sprint/SprintDetail.tsx
+++ b/frontend/src/features/sprint/SprintDetail.tsx
@@ -1,15 +1,19 @@
-import { useParams } from "react-router-dom"
+import { Link, useLocation } from "react-router-dom"
 import { PullRequestList } from "../pullrequestlist/PullRequestList"
-type Params = {
-    sprintId?: string
+import { Sprint } from "../sprintlist/SprintRow"
+
+interface State {
+    sprint: Sprint
 }
 
 export const SprintDetail = () => {
-    const params: Params = useParams<Params>()
+    const location = useLocation();
+    const { sprint } = location.state as State;
+
     return (
         <>
-            <h2>{'Sprint ' + params?.sprintId}</h2>
-            <PullRequestList/>
+            <h2>{'Sprint ' + sprint.id}</h2>
+            <PullRequestList sprint={sprint}/>
         </>
     )
 }

--- a/frontend/src/features/sprintlist/SprintRow.tsx
+++ b/frontend/src/features/sprintlist/SprintRow.tsx
@@ -27,7 +27,7 @@ export const SprintRow: React.FC<SprintProp> = ({sprint}) => {
                     (member: Member) => <img key={member.name} className="inline-block pr-1" src={member.iconURL} width={20} />
                 )}
             </td>
-            <td><Link to={sprint.id.toString()}>詳細</Link></td>
+            <td><Link to={sprint.id.toString()} state={{sprint: sprint}}>詳細</Link></td>
         </tr>
     )
 }


### PR DESCRIPTION
# 概要

スプリントの参加者と期間をbackendに渡して、そのスプリントでmergeしたPR一覧を取得できるようにした

また、APIのレスポンス待ちの間はLoading画面を表示するようにした

# 気になってること
スプリント詳細画面を見るとなぜかAPIが2回叩かれるので、一回だけ叩くようにしたい