### PR TITLE
[frontend] チャートで各スプリントのメトリクスが正しく表示されるように修正した

### DIFF
--- a/frontend/src/features/Chart/DevDayDeveloperChart.tsx
+++ b/frontend/src/features/Chart/DevDayDeveloperChart.tsx
@@ -24,7 +24,7 @@ export const DevDayDeveloperList: React.FC<DevDayDeveloperChartProps> = ({sprint
         datasets: [
           {
             label: 'Dev / Day / Developer',
-            data: devDayDeveloperList.map((metrics) => metrics.score ),
+            data: Object.values(devDayDeveloperList.sort((a, b) => a.sprintId - b.sprintId).reduce((prev, current) => ({[current.sprintId]: current.score,...prev}), {})),
             backgroundColor: 'rgb(75, 192, 192)',
           },
         ],

--- a/frontend/src/features/Chart/MetricsChart.tsx
+++ b/frontend/src/features/Chart/MetricsChart.tsx
@@ -41,22 +41,23 @@ type MetricsChartProps = {
 
 export const MetricsChart: React.FC<MetricsChartProps> = ({sprintList, untilFirstReviewedList, untilLastApprovedList, untilMergedList}) => {
     const labels = sprintList.map((sprint) => sprint.id)
+    console.log(Object.values(untilFirstReviewedList.sort((a, b) => a.sprintId - b.sprintId).reduce((prev, current) => ({[current.sprintId]: current.score,...prev}), {})))
     const datasets = {
         labels,
         datasets: [
           {
             label: 'レビューまでにかかった時間',
-            data: untilFirstReviewedList.map((metrics) => metrics.score),
+            data: Object.values(untilFirstReviewedList.sort((a, b) => a.sprintId - b.sprintId).reduce((prev, current) => ({[current.sprintId]: current.score,...prev}), {})),
             backgroundColor: 'rgb(255, 99, 132)',
           },
           {
             label: '最後のapproveまでにかかった時間',
-            data: untilLastApprovedList.map((metrics) => metrics.score),
+            data: Object.values(untilLastApprovedList.sort((a, b) => a.sprintId - b.sprintId).reduce((prev, current) => ({[current.sprintId]: current.score,...prev}), {})),
             backgroundColor: 'rgb(75, 192, 192)',
           },
           {
             label: 'マージまでにかかった時間',
-            data: untilMergedList.map((metrics) => metrics.score),
+            data: Object.values(untilMergedList.sort((a, b) => a.sprintId - b.sprintId).reduce((prev, current) => ({[current.sprintId]: current.score,...prev}), {})),
             backgroundColor: 'rgb(53, 162, 235)',
           },
         ],

--- a/frontend/src/features/Chart/PrCountChart.tsx
+++ b/frontend/src/features/Chart/PrCountChart.tsx
@@ -35,7 +35,7 @@ export const PrCountChart: React.FC<PrCountChartProps> = ({sprintList, prCountLi
         datasets: [
           {
             label: 'マージしたPR数',
-            data: prCountList.map((metrics) => metrics.score),
+            data: Object.values(prCountList.sort((a, b) => a.sprintId - b.sprintId).reduce((prev, current) => ({[current.sprintId]: current.score,...prev}), {})),
             backgroundColor: 'rgb(255, 99, 132)',
           },
         ],


### PR DESCRIPTION
# 概要

reactがstrictモードで起動しているときにコンポーネントが2回ロードされている関係で、メトリクスデータが重複して2つづつ入っていたことで、データがずれて表示されていた。

そこで、取得したデータを描写するために、sprintIdをkeyにしたマップにデータを入れて、重複データがstateに保存されないように対応した。