### PR TITLE
fix: フロントエンドチャートのちらつき問題を解決

### DIFF
--- a/frontend/src/features/Chart/DevDayDeveloperChart.tsx
+++ b/frontend/src/features/Chart/DevDayDeveloperChart.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { Bar } from "react-chartjs-2";
 import { Sprint } from "../sprintlist/SprintRow";
 import { Metrics } from "./Chart";
@@ -18,17 +19,25 @@ type DevDayDeveloperChartProps = {
 }
 
 export const DevDayDeveloperList: React.FC<DevDayDeveloperChartProps> = ({sprintList, devDayDeveloperList}) => {
-    const labels = sprintList.map((sprint) => sprint.id)
-    const datasets = {
-        labels,
-        datasets: [
-          {
-            label: 'Dev / Day / Developer',
-            data: Object.values(devDayDeveloperList.sort((a, b) => a.sprintId - b.sprintId).reduce((prev, current) => ({[current.sprintId]: current.score,...prev}), {})),
-            backgroundColor: 'rgb(75, 192, 192)',
-          },
-        ],
-      };
+    const datasets = useMemo(() => {
+        const labels = sprintList.map((sprint) => sprint.id);
+        const processedData = Object.values(
+            devDayDeveloperList
+                .sort((a, b) => a.sprintId - b.sprintId)
+                .reduce((prev, current) => ({[current.sprintId]: current.score, ...prev}), {})
+        );
+
+        return {
+            labels,
+            datasets: [
+                {
+                    label: 'Dev / Day / Developer',
+                    data: processedData,
+                    backgroundColor: 'rgb(75, 192, 192)',
+                },
+            ],
+        };
+    }, [sprintList, devDayDeveloperList]);
 
     return (
         <Bar options={chartOptions} data={datasets} />

--- a/frontend/src/features/Chart/MetricsChart.tsx
+++ b/frontend/src/features/Chart/MetricsChart.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useMemo } from "react";
 import { Bar } from "react-chartjs-2";
 import { Sprint } from "../sprintlist/SprintRow";
 import { Metrics } from "./Chart";
@@ -40,31 +40,38 @@ type MetricsChartProps = {
 }
 
 export const MetricsChart: React.FC<MetricsChartProps> = ({sprintList, untilFirstReviewedList, untilLastApprovedList, untilMergedList}) => {
-    const labels = sprintList.map((sprint) => sprint.id)
-    console.log(Object.values(untilFirstReviewedList.sort((a, b) => a.sprintId - b.sprintId).reduce((prev, current) => ({[current.sprintId]: current.score,...prev}), {})))
-    const datasets = {
-        labels,
-        datasets: [
-          {
-            label: 'レビューまでにかかった時間',
-            data: Object.values(untilFirstReviewedList.sort((a, b) => a.sprintId - b.sprintId).reduce((prev, current) => ({[current.sprintId]: current.score,...prev}), {})),
-            backgroundColor: 'rgb(255, 99, 132)',
-          },
-          {
-            label: '最後のapproveまでにかかった時間',
-            data: Object.values(untilLastApprovedList.sort((a, b) => a.sprintId - b.sprintId).reduce((prev, current) => ({[current.sprintId]: current.score,...prev}), {})),
-            backgroundColor: 'rgb(75, 192, 192)',
-          },
-          {
-            label: 'マージまでにかかった時間',
-            data: Object.values(untilMergedList.sort((a, b) => a.sprintId - b.sprintId).reduce((prev, current) => ({[current.sprintId]: current.score,...prev}), {})),
-            backgroundColor: 'rgb(53, 162, 235)',
-          },
-        ],
-      };
-    useEffect(() => {
-        
-    }, []);
+    const datasets = useMemo(() => {
+        const labels = sprintList.map((sprint) => sprint.id);
+
+        const processMetrics = (metrics: Metrics[]) => {
+            return Object.values(
+                metrics
+                    .sort((a, b) => a.sprintId - b.sprintId)
+                    .reduce((prev, current) => ({[current.sprintId]: current.score, ...prev}), {})
+            );
+        };
+
+        return {
+            labels,
+            datasets: [
+                {
+                    label: 'レビューまでにかかった時間',
+                    data: processMetrics(untilFirstReviewedList),
+                    backgroundColor: 'rgb(255, 99, 132)',
+                },
+                {
+                    label: '最後のapproveまでにかかった時間',
+                    data: processMetrics(untilLastApprovedList),
+                    backgroundColor: 'rgb(75, 192, 192)',
+                },
+                {
+                    label: 'マージまでにかかった時間',
+                    data: processMetrics(untilMergedList),
+                    backgroundColor: 'rgb(53, 162, 235)',
+                },
+            ],
+        };
+    }, [sprintList, untilFirstReviewedList, untilLastApprovedList, untilMergedList]);
 
     return (
         <Bar options={chartOptions} data={datasets} />

--- a/frontend/src/features/Chart/PrCountChart.tsx
+++ b/frontend/src/features/Chart/PrCountChart.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { Bar } from "react-chartjs-2";
 import { Sprint } from "../sprintlist/SprintRow";
 import { Metrics } from "./Chart";
@@ -29,17 +30,25 @@ type PrCountChartProps = {
 }
 
 export const PrCountChart: React.FC<PrCountChartProps> = ({sprintList, prCountList}) => {
-    const labels = sprintList.map((sprint) => sprint.id)
-    const datasets = {
-        labels,
-        datasets: [
-          {
-            label: 'マージしたPR数',
-            data: Object.values(prCountList.sort((a, b) => a.sprintId - b.sprintId).reduce((prev, current) => ({[current.sprintId]: current.score,...prev}), {})),
-            backgroundColor: 'rgb(255, 99, 132)',
-          },
-        ],
-      };
+    const datasets = useMemo(() => {
+        const labels = sprintList.map((sprint) => sprint.id);
+        const processedData = Object.values(
+            prCountList
+                .sort((a, b) => a.sprintId - b.sprintId)
+                .reduce((prev, current) => ({[current.sprintId]: current.score, ...prev}), {})
+        );
+
+        return {
+            labels,
+            datasets: [
+                {
+                    label: 'マージしたPR数',
+                    data: processedData,
+                    backgroundColor: 'rgb(255, 99, 132)',
+                },
+            ],
+        };
+    }, [sprintList, prCountList]);
 
     return (
         <Bar options={chartOptions} data={datasets} />

--- a/frontend/src/features/Chart/hooks/useBatchPullRequests.ts
+++ b/frontend/src/features/Chart/hooks/useBatchPullRequests.ts
@@ -36,12 +36,22 @@ export const useBatchPullRequests = (sprintList: Sprint[]) => {
           sprintList[0].endDate
         );
 
+        // 全スプリントの全メンバーを統合
+        const allMembers = sprintList.reduce((members, sprint) => {
+          sprint.members.forEach(member => {
+            if (!members.find(m => m.name === member.name)) {
+              members.push(member);
+            }
+          });
+          return members;
+        }, [] as typeof sprintList[0]['members']);
+
         // 全期間のPull Requestsを1回のAPI呼び出しで取得
         const allPullRequests = await FetchPullRequests({
           id: 0, // バッチ用の仮ID
           startDate: earliestDate,
           endDate: latestDate,
-          members: [] // 全メンバーを取得
+          members: allMembers // 統合した全メンバー
         });
 
         // epicブランチを除外


### PR DESCRIPTION
## Summary
フロントエンドのチャート画面で発生していたちらつき問題を解決しました。

## 主要な変更点
- **パフォーマンス最適化**: 3つのチャートコンポーネントで重複除去処理をuseMemoで最適化
- **不要なログ削除**: MetricsChart.tsxの不要なconsole.logを削除
- **API問題修正**: useBatchPullRequestsのempty developersパラメータ問題を解決

## 技術的詳細
### 修正されたファイル
- `MetricsChart.tsx`: console.log削除、データ処理をuseMemoで最適化
- `PrCountChart.tsx`: データ処理をuseMemoで最適化
- `DevDayDeveloperChart.tsx`: データ処理をuseMemoで最適化
- `useBatchPullRequests.ts`: 全スプリントのメンバーを統合してAPIに送信

### 問題の原因
1. レンダリング毎に実行される重複除去処理（ソート→reduce）
2. 不要なconsole.log出力
3. APIリクエストでempty developersパラメータによる400エラー

### 解決策
1. `useMemo`フックを使用してデータ処理をメモ化
2. 不要なログ出力を削除
3. 全スプリントのメンバーを統合してAPIに正しく送信

## Test plan
- [x] ローカル環境でチャート画面のちらつきが解消されたことを確認
- [x] 各チャートコンポーネントが正常にレンダリングされることを確認
- [x] APIエラーが解消されたことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)